### PR TITLE
Accept separate encodings for input and ouput

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2012-03-13    Akinori MUSHA  <knu@iDaemons.org>
+
+	* cocot.c, loop.c, loop.h: accept separate encodings for input and
+	ouput, allowing normalization of UTF-8-MAC to UTF-8 for example.
+
 2010-09-03    YAMAGUCHI Takanori
 
 	* cocot.c, init.c, config.h.in, configure.ac: add Solaris /

--- a/README.ja
+++ b/README.ja
@@ -117,8 +117,12 @@ ja_JP.eucJP
 
   -o LOGFILE	 コード変換前のコマンドの出力を全てファイルに出力します。
   -a		 -oオプション指定時に追記モードにします。
-  -t TERM_CODE	 ターミナルの文字コードを指定します。デフォルトはCP932。
-  -p PROC_CODE	 コマンドプロセスの文字コードを指定します。デフォルトはEUC-JP。
+  -t TERM_CODE
+  -t TERM_INPUT_CODE,TERM_OUTPUT_CODE
+		 ターミナルの文字コードを指定します。デフォルトはCP932。
+  -p PROC_CODE
+  -t PROC_INPUT_CODE,PROC_OUTPUT_CODE
+		 コマンドプロセスの文字コードを指定します。デフォルトはEUC-JP。
   -i		 ISO-2022-JPのエスケープシーケンスを無視します。
   -n		 無変換モードにします。-oオプションを組み合わせて、script(1)
 		 の代わりに使用します。

--- a/cocot.c
+++ b/cocot.c
@@ -57,8 +57,12 @@ usage(int argc, char *argv[])
 	    "Options:\n"
 	    "    -o LOGFILE     logging all output of command.\n"
 	    "    -a             append log file.\n"
-	    "    -t TERM_CODE   character code in terminal. (default is %s)\n"
-	    "    -p PROC_CODE   character code in command process. (default is %s)\n"
+	    "    -t TERM_CODE\n"
+	    "    -t TERM_INPUT_CODE,TERM_OUTPUT_CODE\n"
+            "                   character encoding(s) for terminal. (default is %s)\n"
+	    "    -p PROC_CODE\n"
+	    "    -p PROC_INPUT_CODE,PROC_OUTPUT_CODE\n"
+	    "                   character encoding(s) in command process. (default is %s)\n"
 	    "    -i             ignore ISO-2022-JP escape sequence.\n"
 	    "    -n             no conversion. (like script(1))\n"
 	    "    -h, --help     show this message.\n"
@@ -77,8 +81,11 @@ main(int argc, char *argv[])
     char *logfn = NULL;
     char *logmd = "w";
     FILE *logfp = NULL;
-    char *term_code = DEFAULT_TERM_CODE;
-    char *proc_code = DEFAULT_PROC_CODE;
+    char *term_input_code  = DEFAULT_TERM_CODE;
+    char *term_output_code = DEFAULT_TERM_CODE;
+    char *proc_input_code  = DEFAULT_PROC_CODE;
+    char *proc_output_code = DEFAULT_PROC_CODE;
+    char *p;
     int dec_jis = 1;
 
     int mfd, sfd;
@@ -102,16 +109,29 @@ main(int argc, char *argv[])
 	    logfn = optarg;
 	    break;
 	case 't':
-	    term_code = optarg;
+	    if ((p = strchr(optarg, ',')) != NULL) {
+		term_input_code = optarg;
+		*p++ = '\0';
+		term_output_code = p;
+	    } else {
+		term_input_code = term_output_code = optarg;
+	    }
 	    break;
 	case 'p':
-	    proc_code = optarg;
+	    if ((p = strchr(optarg, ',')) != NULL) {
+		proc_input_code = optarg;
+		*p++ = '\0';
+		proc_output_code = p;
+	    } else {
+		proc_input_code = proc_output_code = optarg;
+	    }
 	    break;
 	case 'i':
 	    dec_jis = 0;
 	    break;
 	case 'n':
-	    term_code = proc_code = NULL;
+	    term_input_code = term_output_code =
+	    proc_input_code = proc_output_code = NULL;
 	    break;
 	case 'h':
 	    usage(argc, argv);
@@ -156,7 +176,9 @@ main(int argc, char *argv[])
 	fatal("Can't open file '%s' (%s).", DEBUG_LOG, strerror(errno));
     setvbuf(debug, NULL, _IONBF, 0);
 #endif
-    loop(mfd, logfp, term_code, proc_code, dec_jis);
+    loop(mfd, logfp,
+	 term_input_code, term_output_code,
+	 proc_input_code, proc_output_code, dec_jis);
     close(mfd);
     if (logfp)
 	fclose(logfp);

--- a/loop.c
+++ b/loop.c
@@ -28,17 +28,22 @@
 #endif
 
 void
-loop(int mfd, FILE *fp, char *term_code, char *proc_code, int dec_jis)
+loop(int mfd, FILE *fp,
+     char *term_input_code, char *term_output_code,
+     char *proc_input_code, char *proc_output_code,
+     int dec_jis)
 {
     CCIO master, slave;
     fd_set fds;
     int fdmax = max(STDIN_FILENO, STDOUT_FILENO) + 1;
     if (fdmax < mfd)
 	fdmax = mfd + 1;
-    if (ccio_init(&master, proc_code, term_code, 0) == CCIO_ERROR ||
-	ccio_init(&slave, term_code, proc_code, dec_jis) == CCIO_ERROR)
-	fatal("%s: TERM_CODE(%s) and/or PROC_CODE(%s) is invalid.",
-	      strerror(errno), term_code, proc_code);
+    if (ccio_init(&master, proc_input_code, term_input_code, 0) == CCIO_ERROR ||
+	ccio_init(&slave, term_output_code, proc_output_code, dec_jis) == CCIO_ERROR)
+	fatal("%s: TERM_CODE(%s,%s) and/or PROC_CODE(%s,%s) is invalid.",
+	      strerror(errno),
+	      term_input_code, term_output_code,
+	      proc_input_code, proc_output_code);
     reg_sigwinch(mfd);
     while (1) {
 	FD_ZERO(&fds);

--- a/loop.h
+++ b/loop.h
@@ -11,6 +11,9 @@
 #include <stdio.h>
 
 void
-loop(int mfd, FILE *fp, char *term_code, char *proc_code, int dec_jis);
+loop(int mfd, FILE *fp,
+     char *term_input_code, char *term_output_code,
+     char *proc_input_code, char *proc_output_code,
+     int dec_jis);
 
 #endif /* LOOP_H */


### PR DESCRIPTION
Macの標準コマンドはパス名などをNFDのUTF-8で出力しますが、これをNFCに変換してくれるシェル環境を起動したい場合、

```
cocot -p UTF-8-MAC -t UTF-8 zsh
```

とすればよさそうに思えます。ところが、これではキーボードからの入力がNFDに変換されてプロセスに送られてしまい困ります。

本修正はプロセスの出力エンコーディングとプロセスへの入力エンコーディングを別に指定できるようにするものです。

```
cocot -p UTF-8,UTF-8-MAC -t UTF-8 zsh
```
