### PR TITLE
Allow coprocess to suspend

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = cocot
-cocot_SOURCES = ccio.c ccio.h cocot.c init.c init.h l10n_ja.c l10n_ja.h l10n_cjk_uni.c l10n_cjk_uni.h l10n_cjk_uni_table.c l10n_cjk_uni_table.h loop.c loop.h sigwinch.c sigwinch.h malloc.c debug.h
+cocot_SOURCES = ccio.c ccio.h cocot.c init.c init.h l10n_ja.c l10n_ja.h l10n_cjk_uni.c l10n_cjk_uni.h l10n_cjk_uni_table.c l10n_cjk_uni_table.h loop.c loop.h sigwinch.c sigwinch.h suspend.c suspend.h malloc.c debug.h
 EXTRA_DIST = ChangeLog.ja README.ja UNICODE_MEMO make_l10n_cjk_uni_table.sh make_l10n_cjk_uni_table.pl cygwin-install.sh cocot.exe
 
 mydist::

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,8 @@ AC_CHECK_HEADERS([iconv.h],,[AC_MSG_ERROR(iconv.h is not available)])
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS([stdlib.h string.h sys/ioctl.h sys/time.h termios.h unistd.h utmp.h])
-AC_CHECK_HEADERS([libutil.h pty.h])
+AC_CHECK_HEADERS([libutil.h util.h pty.h])
+AC_CHECK_HEADERS([signal.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/init.h
+++ b/init.h
@@ -1,11 +1,17 @@
 #ifndef INIT_H
 #define INIT_H
 
+struct termios;
+struct winsize;
+
 void
 init(int *mfd_p, int *sfd_p);
 
 void
-done(void);
+init_tty(int mfd, struct termios *term_p, struct winsize *win_p);
+
+void
+reset_tty(void);
 
 void
 fatal(const char *fmt, ...);

--- a/loop.c
+++ b/loop.c
@@ -17,11 +17,15 @@
 #if HAVE_SYS_TIME_H
 #  include <sys/time.h>
 #endif
+#if HAVE_STRING_H
+#  include <string.h>
+#endif
 #include <errno.h>
 
 #include "init.h"
 #include "sigwinch.h"
 #include "ccio.h"
+#include "suspend.h"
 
 #ifndef HAVE_MAX
 #define max(a, b) ((a) > (b) ? (a) : (b))
@@ -45,7 +49,16 @@ loop(int mfd, FILE *fp,
 	      term_input_code, term_output_code,
 	      proc_input_code, proc_output_code);
     reg_sigwinch(mfd);
+    reg_sigtstp();
     while (1) {
+	if (do_tstp) {
+	    do_tstp = 0;
+    	    rm_sigtstp();
+	    reset_tty();
+	    do_suspend();
+	    init_tty(mfd, NULL, NULL);
+    	    reg_sigtstp();
+	}
 	FD_ZERO(&fds);
 	FD_SET(STDIN_FILENO, &fds);
 	FD_SET(mfd, &fds);
@@ -62,6 +75,7 @@ loop(int mfd, FILE *fp,
 	if (ccio_write(&slave, STDOUT_FILENO) == CCIO_ERROR)
 	    break;
     }
+    rm_sigtstp();
     rm_sigwinch();
     ccio_done(&master);
     ccio_done(&slave);

--- a/loop.c
+++ b/loop.c
@@ -20,6 +20,9 @@
 #if HAVE_STRING_H
 #  include <string.h>
 #endif
+#if HAVE_SIGNAL_H
+#  include <signal.h>
+#endif
 #include <errno.h>
 
 #include "init.h"
@@ -55,7 +58,7 @@ loop(int mfd, FILE *fp,
 	    do_tstp = 0;
     	    rm_sigtstp();
 	    reset_tty();
-	    do_suspend();
+	    kill(0, SIGTSTP);
 	    init_tty(mfd, NULL, NULL);
     	    reg_sigtstp();
 	}

--- a/sigwinch.c
+++ b/sigwinch.c
@@ -14,7 +14,9 @@
 #if HAVE_TERMIOS_H
 #  include <termios.h>
 #endif
-#include <signal.h>
+#if HAVE_SIGNAL_H
+#  include <signal.h>
+#endif
 #if HAVE_SYS_TYPES_H
 #  include <sys/types.h>
 #endif

--- a/suspend.c
+++ b/suspend.c
@@ -1,0 +1,70 @@
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+#include "errno.h"
+#if HAVE_SIGNAL_H
+#  include <signal.h>
+#endif
+#if HAVE_STRING_H
+#  include <string.h>
+#endif
+#if HAVE_UNISTD_H
+#  include <unistd.h>
+#endif
+
+#include "init.h"
+
+int do_tstp = 0;
+
+static struct sigaction oact;
+
+void
+sigtstp(int unused)
+{
+
+	do_tstp = 1;
+}
+
+int
+reg_sigtstp(void)
+{
+    struct sigaction act;
+
+    act.sa_handler = sigtstp;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = SA_RESTART;
+    return sigaction(SIGTSTP, &act, &oact);
+}
+
+int
+rm_sigtstp(void)
+{
+
+    return sigaction(SIGTSTP, &oact, NULL);
+}
+
+void
+do_suspend(void)
+{
+
+    kill(0, SIGTSTP);
+}
+
+void
+setfg(void)
+{
+    sigset_t osigset, nsigset;
+
+    sigemptyset(&nsigset);
+    sigaddset(&nsigset, SIGTSTP);
+    sigaddset(&nsigset, SIGTTIN);
+    sigaddset(&nsigset, SIGTTOU);
+    sigprocmask(SIG_BLOCK, &nsigset, &osigset);
+
+    if (setpgid(0, 0))
+	fatal("setpgid %s", strerror(errno));
+    if (tcsetpgrp(0, getpid()))
+	fatal("tcsetpgrp %s", strerror(errno));
+
+    sigprocmask(SIG_SETMASK, &osigset, NULL);
+}

--- a/suspend.c
+++ b/suspend.c
@@ -48,6 +48,10 @@ setfg(void)
 {
     sigset_t osigset, nsigset;
 
+    /*
+     * Block the tty signals till things set correctly. 
+     * Taken from util.c of csh in NetBSD.
+     */
     sigemptyset(&nsigset);
     sigaddset(&nsigset, SIGTSTP);
     sigaddset(&nsigset, SIGTTIN);

--- a/suspend.c
+++ b/suspend.c
@@ -44,13 +44,6 @@ rm_sigtstp(void)
 }
 
 void
-do_suspend(void)
-{
-
-    kill(0, SIGTSTP);
-}
-
-void
 setfg(void)
 {
     sigset_t osigset, nsigset;

--- a/suspend.h
+++ b/suspend.h
@@ -1,0 +1,11 @@
+extern int do_tstp;
+
+void sigtstp(int);
+
+int reg_sigtstp(void);
+
+int rm_sigtstp(void);
+
+void do_suspend(void);
+
+void setfg(void);


### PR DESCRIPTION
Hi,

With this change, a coprocess working on cocot can suspend when it tries.
In the previous version, this is impossible because the coprocess is orphan.
In order to realize this feature, double-fork technique is utilized in cocot.c.

I've checked compile & run on NetBSD, macOS, Linux, and Solaris.

Also, some compiler warnings are appeased.

Please regenerate autotool stuffs (generated files are not contained in the tree).